### PR TITLE
Add shebangs and to path

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
+{
+	"name": "Python 3",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/python:0-3.11",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			"settings": {},
+			"extensions": [
+				"streetsidesoftware.code-spell-checker"
+			]
+		}
+	},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [9000],
+
+	// Use 'portsAttributes' to set default properties for specific forwarded ports. 
+	// More info: https://containers.dev/implementors/json_reference/#port-attributes
+	"portsAttributes": {
+		"9000": {
+			"label": "Hello Remote World",
+			"onAutoForward": "notify"
+		}
+	}
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,3 +7,5 @@ COPY SADET.py /inpred
 # initialize the necessary gpg directories
 RUN echo "GPG init" | gpg -c --passphrase "init" --batch --cipher-algo aes256 -o /inpred/resources/data.init.gpg
 RUN rm /inpred/resources/data.init.gpg
+# Add SADET.py to PATH
+ENV PATH=$PATH:/inpred

--- a/SADET.py
+++ b/SADET.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """Extract sample data of specified patients (from LocalApp or TSOPPI output directories)."""
 import argparse
 from datetime import datetime
@@ -685,6 +686,7 @@ def main():
     # - md5sum is run on regular files only (not directories)
     if (selected_file_count > 0):
         with open(outfile_script_path_cont, "w") as esp_outfile:
+            esp_outfile.write("#!/bin/bash\n")
             esp_outfile.write("# packaging and encryption of selected files\n")
             esp_outfile.write("if [ -f " + outfile_archive_path + " ]; then rm " + outfile_archive_path + " ; fi\n")
             esp_outfile.write("tar -C " + outfile_dir_parent_path + " -T " + outfile_file_path_list + " -c"


### PR DESCRIPTION
I added shebangs for `SADET.py` and the export script and also added `SADET.py` to the `$PATH` inside the docker images.

Please ignore the `.devcontainer` directory as it is part of a different PR.

Closes #7 

Closes #15 